### PR TITLE
Allow injecting custom app version and code from AnalyticsBuilder

### DIFF
--- a/analytics/src/main/java/com/segment/analytics/AnalyticsContext.java
+++ b/analytics/src/main/java/com/segment/analytics/AnalyticsContext.java
@@ -215,6 +215,16 @@ public class AnalyticsContext extends ValueMap {
     }
   }
 
+  public AnalyticsContext putVersionName(String version) {
+    ValueMap app = getValueMap(APP_KEY).putValue(APP_VERSION_KEY, version);
+    return putValue(APP_KEY, app);
+  }
+
+  public AnalyticsContext putVersionCode(int versionCode) {
+    ValueMap app = getValueMap(APP_KEY).putValue(APP_BUILD_KEY, String.valueOf(versionCode));
+    return putValue(APP_KEY, app);
+  }
+
   /** Set information about the campaign that resulted in the API call. */
   public AnalyticsContext putCampaign(Campaign campaign) {
     return putValue(CAMPAIGN_KEY, campaign);

--- a/analytics/src/test/java/com/segment/analytics/AnalyticsContextTest.java
+++ b/analytics/src/test/java/com/segment/analytics/AnalyticsContextTest.java
@@ -102,6 +102,24 @@ public class AnalyticsContextTest {
   }
 
   @Test
+  public void putVersionNameOverridesDefault() {
+    context = AnalyticsContext.create(RuntimeEnvironment.application, traits, false)
+            .putVersionName("10.0");
+
+    assertThat(context.getValueMap("app")) //
+            .containsEntry("version", "10.0");
+  }
+
+  @Test
+  public void putVersionCodeOverridesDefault() {
+    context = AnalyticsContext.create(RuntimeEnvironment.application, traits, false)
+            .putVersionCode(10);
+
+    assertThat(context.getValueMap("app")) //
+            .containsEntry("build", "10");
+  }
+
+  @Test
   public void createWithoutDeviceIdCollection() {
     context = AnalyticsContext.create(RuntimeEnvironment.application, traits, false);
 


### PR DESCRIPTION
This is the first step to modifying our fork of [Segment Android](https://github.com/segmentio/analytics-android) that will allow us to inject our own app version from javascript, and track version changes when we integrate fully with Codepush.

1. Modifies the `AnalyticsContext` object to allow an overridden version name and code
1. Modifies the `Analytics` object to send the provided version code during application install track events. 

I don't expect a full review since obviously none of us are intimately familiar with this library, but just take a look and make sure it all looks sane. Thanks!